### PR TITLE
Remove map

### DIFF
--- a/models/events.go
+++ b/models/events.go
@@ -141,7 +141,6 @@ type GameEndedEvent struct {
 	PlayerWinnerName  string  `json:"playerWinnerName"`
 	GameID            string  `json:"gameId"`
 	GameTick          int     `json:"gameTick"`
-	Map               Map     `json:"map"`
 	ReceivingPlayerID *string `json:"receivingPlayerId"`
 	Timestamp         int     `json:"timestamp"`
 }


### PR DESCRIPTION
Unmarsah gave a panic sometimes. It seems to be cause ExplosionInfos was unable to be decode when an array of zeros. Didn't see the need for Map in GameEndedEvent, so I removed it.