### PR TITLE
Use wss scheme to connect to server

### DIFF
--- a/basebot/connection.go
+++ b/basebot/connection.go
@@ -11,8 +11,8 @@ import (
 
 func getWebsocketConnection(gameMode models.GameMode) *websocket.Conn {
 	var u = url.URL{
-		Scheme: "ws",
-		Host:   "server.paintbot.cygni.se:80",
+		Scheme: "wss",
+		Host:   "server.paintbot.cygni.se",
 		//Host: "localhost:8080",
 		Path: string(gameMode),
 	}


### PR DESCRIPTION
Updates the scheme used to connect to the paintbot server. Without this change the user would just get connection refused